### PR TITLE
Upd/svc dns

### DIFF
--- a/charts/universal-helm/Chart.yaml
+++ b/charts/universal-helm/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 
 type: application
 
-version: 0.6.11
+version: 0.6.12

--- a/charts/universal-helm/templates/service.yaml
+++ b/charts/universal-helm/templates/service.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   selector:
     statefulsetname: {{ $sts.name }}
+  publishNotReadyAddresses: true
   ports:
     #! Headless service's port doesn't matter coz you addressing pod directly
     - port: 12345


### PR DESCRIPTION
Note:
A and AAAA records are not created for Pod names since hostname is missing for the Pod. A Pod with no hostname but with subdomain will only create the A or AAAA record for the headless Service (busybox-subdomain.my-namespace.svc.cluster-domain.example), pointing to the Pods' IP addresses. Also, the Pod needs to be ready in order to have a record unless publishNotReadyAddresses=True is set on the Service.

[Link](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields)