### PR TITLE
feat - ethereum-reth-nimbus v0.0.64: as p2pNlb nameOverride

### DIFF
--- a/charts/ethereum-reth-nimbus/Chart.yaml
+++ b/charts/ethereum-reth-nimbus/Chart.yaml
@@ -6,6 +6,6 @@ home: https://soneium.com
 sources:
   - https://github.com/soneium
 type: application
-version: 0.0.63
+version: 0.0.64
 maintainers:
   - name: vlad

--- a/charts/ethereum-reth-nimbus/ReadMe.md
+++ b/charts/ethereum-reth-nimbus/ReadMe.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.64
+  Added `nameOverride` over `p2pNlb` to harcode load-balancer name if chosen.
+  Breaking changes - NO.
+
 ## 0.0.63
   Breaking changes - NO.
 
@@ -23,4 +27,3 @@ Changes:
 
 Changes:
 - Add readiness probe sidecar, so STS's pods will wait when each upgraded pod become ready, before upgrading the next one.
-

--- a/charts/ethereum-reth-nimbus/templates/_helpers.tpl
+++ b/charts/ethereum-reth-nimbus/templates/_helpers.tpl
@@ -66,3 +66,16 @@ S3 bucket name and path to store/get restic repo
 {{- define "node.resticS3Repo" -}}
 {{- printf "s3:https://s3.amazonaws.com/%s/%s/%s" .Values.dataSnapshot.bucketName .Values.ethereumChain .Values.dataSnapshot.ethereumClients }}
 {{- end }}
+
+{{/*
+Returns the final LoadBalancer name:
+- Use .Values.p2pNlb.nameOverride if provided
+- Otherwise, fallback to "$LB_NAME" (set at runtime in the shell script)
+*/}}
+{{- define "node.p2pLbName" -}}
+{{- if .Values.p2pNlb.nameOverride -}}
+{{ .Values.p2pNlb.nameOverride | trunc 32 | trimSuffix "-" }}
+{{- else -}}
+$LB_NAME
+{{- end -}}
+{{- end }}

--- a/charts/ethereum-reth-nimbus/templates/statefulset.yaml
+++ b/charts/ethereum-reth-nimbus/templates/statefulset.yaml
@@ -195,7 +195,7 @@ spec:
                 annotations:
                   argocd.argoproj.io/compare-options: IgnoreExtraneous
                   argocd.argoproj.io/sync-options: Prune=false
-                  service.beta.kubernetes.io/aws-load-balancer-name: $LB_NAME
+                  service.beta.kubernetes.io/aws-load-balancer-name: {{ include "node.p2pLbName" . }}
                   service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
                   service.beta.kubernetes.io/aws-load-balancer-type: external
                   service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip

--- a/charts/ethereum-reth-nimbus/test-values.yaml
+++ b/charts/ethereum-reth-nimbus/test-values.yaml
@@ -35,6 +35,7 @@ p2pNlb:
   securityGroup: some-security-group-id
   #* Subnet name without az name, subnets should be named in the following way: `${publicSubnetPrefix}-${azName}`.
   subnetPrefix: some-subnet-name
+  nameOverride: some-lb-name
 
 vmPodScrape:
   region: shortregion

--- a/charts/ethereum-reth-nimbus/values.yaml
+++ b/charts/ethereum-reth-nimbus/values.yaml
@@ -86,6 +86,7 @@ p2pNlb:
   securityGroup: ""
   #* Subnet name without az name, subnets should be named in the following way: `${publicSubnetPrefix}-${azName}`.
   subnetPrefix: ""
+  nameOverride: ""
 
 ingress:
   # -- Ingress resource for the HTTP API


### PR DESCRIPTION
**ethereum-reth-nimbus chart, v0.0.64**

Added `nameOverride` to `p2pNlb` for manually defining load-balancer names.